### PR TITLE
feat: BaseError extension

### DIFF
--- a/packages/base-error/CHANGELOG.md
+++ b/packages/base-error/CHANGELOG.md
@@ -1,12 +1,19 @@
 # @corebits/base-error
 
-## 1.1.0
+## 1.2.0
 
 ### Minor Changes
 
+- Extends `BaseError` object with `causedBy` error access
+- Fixes "Caused by" stack building logic
+
+## 1.1.0
+ 
+### Minor Changes
+
 - Extends `BaseError` class
-    - Adds error mark
-    - Adds static method `isCorebitsError`
+  - Adds error mark
+  - Adds static method `isCorebitsError`
 
 ## 1.0.0
 

--- a/packages/base-error/package.json
+++ b/packages/base-error/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@corebits/base-error",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "CoreBits Base Error package",
   "author": "Mavricus",
   "license": "MIT",

--- a/packages/base-error/tests/unit/base-error.test.ts
+++ b/packages/base-error/tests/unit/base-error.test.ts
@@ -56,4 +56,80 @@ describe('BaseError', () => {
       expect(BaseError.isCorebitsError(undefined)).toBe(false);
     });
   });
+
+  describe('causedBy', () => {
+    it('should provide access to the original error', () => {
+      const originalError = new Error('Original error');
+      const error = new TestError('Test', { test: 'test' }, originalError);
+
+      expect(error.causedBy).toBe(originalError);
+    });
+
+    it('should include the original error in the stack', () => {
+      const originalError = new Error('Original error');
+      const error = new TestError('Test', { test: 'test' }, originalError);
+
+      expect(error.stack).toContain('Caused by: Error: Original error');
+    });
+
+    it('should allow for a custom error as the original error', () => {
+      const originalError = new TestError('Original error', { test: 'original' });
+      const error = new TestError('Test', { test: 'test' }, originalError);
+
+      expect(error.stack).toContain('Caused by: TestError: Original error');
+    });
+
+    it('should not include the original error if not provided', () => {
+      const error = new TestError('Test', { test: 'test' });
+
+      expect(error.stack).not.toContain('Caused by:');
+    });
+
+    it('should not include the original error if null', () => {
+      const error = new TestError('Test', { test: 'test' }, null as unknown as Error);
+
+      expect(error.stack).not.toContain('Caused by:');
+    });
+
+    it('should not include the original error if undefined', () => {
+      const error = new TestError('Test', { test: 'test' }, undefined);
+
+      expect(error.stack).not.toContain('Caused by:');
+    });
+
+    it('should allow custom error to be a string', () => {
+      const error = new TestError('Test', { test: 'test' }, 'Original error' as unknown as Error);
+
+      expect(error.stack).toContain('Caused by: Original error');
+    });
+
+    it('should allow custom error to be an object', () => {
+      const error = new TestError('Test', { test: 'test' }, {
+        name: 'CustomError',
+        message: 'Custom error',
+      } as unknown as Error);
+
+      expect(error.stack).toContain('Caused by: CustomError: Custom error');
+    });
+
+    it('should allow custom error to be an object with no message', () => {
+      const error = new TestError('Test', { test: 'test' }, { name: 'CustomError' } as unknown as Error);
+      expect(error.stack).toContain('Caused by: CustomError');
+    });
+
+    it('should allow custom error to be an object with no name', () => {
+      const error = new TestError('Test', { test: 'test' }, { message: 'Custom error' } as unknown as Error);
+      expect(error.stack).toContain('Caused by: Custom error');
+    });
+
+    it('should allow custom error to be an object with no name or message', () => {
+      const error = new TestError('Test', { test: 'test' }, {} as unknown as Error);
+      expect(error.stack).not.toContain('Caused by');
+    });
+
+    it('should allow custom error to be an object with stack', () => {
+      const error = new TestError('Test', { test: 'test' }, { stack: 'CustomErrorStack' } as unknown as Error);
+      expect(error.stack).toContain('Caused by: CustomErrorStack');
+    });
+  });
 });

--- a/packages/kvs-core/CHANGELOG.md
+++ b/packages/kvs-core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @corebits/kvs-core
 
+## 1.1.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @corebits/base-error@1.2.0
+
 ## 1.1.1
 
 ### Patch Changes

--- a/packages/kvs-core/package.json
+++ b/packages/kvs-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@corebits/kvs-core",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Flex Clatform Key-Value Storage Core package",
   "author": "Mavricus",
   "license": "MIT",

--- a/packages/kvs-in-memory/CHANGELOG.md
+++ b/packages/kvs-in-memory/CHANGELOG.md
@@ -1,12 +1,20 @@
 # @corebits/kvs-in-memory
 
+## 1.1.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @corebits/base-error@1.2.0
+  - @corebits/kvs-core@1.1.2
+
 ## 1.1.1
 
 ### Patch Changes
 
 - Updated dependencies
-    - @corebits/base-error@1.1.0
-    - @corebits/kvs-core@1.1.1
+  - @corebits/base-error@1.1.0
+  - @corebits/kvs-core@1.1.1
 
 ## 1.1.0
 
@@ -24,5 +32,5 @@
 ### Patch Changes
 
 - Updated dependencies
-    - @corebits/base-error@1.0.0
-    - @corebits/kvs-core@1.0.0
+  - @corebits/base-error@1.0.0
+  - @corebits/kvs-core@1.0.0

--- a/packages/kvs-in-memory/package.json
+++ b/packages/kvs-in-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@corebits/kvs-in-memory",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "CoreBits Key-Value Storage Core package",
   "author": "Mavricus",
   "license": "MIT",

--- a/packages/logger-sonic-boom/CHANGELOG.md
+++ b/packages/logger-sonic-boom/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @corebits/logger-sonic-boom
 
+## 1.0.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @corebits/base-error@1.2.0
+  - @corebits/logger-core@1.1.0
+
 ## 1.0.0
 
 ### Major Changes

--- a/packages/logger-sonic-boom/package.json
+++ b/packages/logger-sonic-boom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@corebits/logger-sonic-boom",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "CoreBits Logger Sonic-Boom package",
   "author": "Mavricus",
   "license": "MIT",

--- a/packages/promise/CHANGELOG.md
+++ b/packages/promise/CHANGELOG.md
@@ -1,14 +1,21 @@
 ## 1.0.0
 
+## 1.0.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @corebits/base-error@1.2.0
+
 ## 1.0.1
 
 ### Patch Changes
 
 - Updated dependencies
-    - @corebits/base-error@1.1.0
+  - @corebits/base-error@1.1.0
 
 ### Major Changes
 
 - Introduces the new Promise package
-    - Implements Delayed promise
-    - Implements Interruptible timer
+  - Implements Delayed promise
+  - Implements Interruptible timer

--- a/packages/promise/package.json
+++ b/packages/promise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@corebits/promise",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "CoreBits Promise package",
   "author": "Mavricus",
   "license": "MIT",


### PR DESCRIPTION
feat: BaseError extension
- Extends `BaseError` object with `causedBy` error access
- Fixes "Caused by" stack building logic